### PR TITLE
Set WASM=1 in CCFLAGS.  Without this, assembly.js is not generated.

### DIFF
--- a/test/makefile
+++ b/test/makefile
@@ -25,7 +25,7 @@ FC:=emfc.sh
 CC:=emcc
 WLD:=emcc
 FCFLAGS:=$(DEBUG) $(OPT) -Wall
-CCFLAGS:=$(DEBUG) --target=wasm32-unknown-emscripten $(OPT) -c -flto -emit-llvm -m32 -Isrc -Wall
+CCFLAGS:=$(DEBUG) --target=wasm32-unknown-emscripten $(OPT) -c -flto -emit-llvm -m32 -Isrc -Wall -s WASM=1
 EMSFLAGS:=$(OPT) $(DEBUG) -m32 -Wall -flto
 WLDFLAGS:=-s WASM=1 -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]' -s MODULARIZE=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s 'EXPORT_NAME="createModule"'
 #  -s USE_SDL=2 -s LEGACY_GL_EMULATION=1


### PR DESCRIPTION
I needed to add this compiler flag in order to have `assembly.js` compiled. Without the flag, `assembly.wasm` is generated, but not `assembly.js`. YMMV.